### PR TITLE
Add support for exec and query

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Since `microrm` uses `$` for named parameters, if you need to use a literal `$` 
 - [x] Support for `delete`ing multiple structs via `DB.DeleteRecords`.
 - [x] Support for transactions via `DB.Transaction`
 - [x] Updates `created_at` and `updated_at` fields automatically.
-- [ ] Support for standard DB `Exec` with named parameters.
-- [ ] Support for standard DB `Query` with named parameters.
 - [x] Pluralize table names by default
+- [x] Support for standard DB `Exec` with named parameters.
+- [x] Support for standard DB `Query` with named parameters.
 
 Not in scope, but welcome contributions:
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Since `microrm` uses `$` for named parameters, if you need to use a literal `$` 
 - [x] Support for `delete`ing multiple structs via `DB.DeleteRecords`.
 - [x] Support for transactions via `DB.Transaction`
 - [x] Updates `created_at` and `updated_at` fields automatically.
-- [x] Pluralize table names by default
 - [x] Support for standard DB `Exec` with named parameters.
 - [x] Support for standard DB `Query` with named parameters.
+- [x] Pluralize table names by default
 
 Not in scope, but welcome contributions:
 

--- a/microrm.go
+++ b/microrm.go
@@ -416,7 +416,9 @@ func (d *DB) Update(ctx context.Context, structType any, queryFragment string, a
 	return rows, nil
 }
 
-// Query executes a query with named parameters and returns the resulting rows.
+// Query calls the underlying sql.DB Query method, but uses named parameters
+// like other microrm methods. Query returns sql.Rows, which the caller is
+// responsible for closing.
 func (d *DB) Query(ctx context.Context, sql string, args map[string]any) (*sql.Rows, error) {
 	sql, argSlice, err := d.replaceNames(sql, args)
 	if err != nil {
@@ -425,7 +427,8 @@ func (d *DB) Query(ctx context.Context, sql string, args map[string]any) (*sql.R
 	return d.db.QueryContext(ctx, sql, argSlice...)
 }
 
-// Exec executes a query with named parameters and without returning rows.
+// Exec calls the underlying sql.DB Exec method, but uses named parameters like
+// other microrm methods.
 func (d *DB) Exec(ctx context.Context, sql string, args map[string]any) (sql.Result, error) {
 	sql, argSlice, err := d.replaceNames(sql, args)
 	if err != nil {
@@ -434,6 +437,8 @@ func (d *DB) Exec(ctx context.Context, sql string, args map[string]any) (sql.Res
 	return d.db.ExecContext(ctx, sql, argSlice...)
 }
 
+// UpdateRecord updates a single record in the database based on the provided struct.
+// The dest parameter should be a pointer to a struct of the record to update.
 func (d *DB) UpdateRecord(ctx context.Context, dest any, updates Updates) error {
 	model, err := d.newModelType(dest)
 	if err != nil {

--- a/microrm.go
+++ b/microrm.go
@@ -416,6 +416,24 @@ func (d *DB) Update(ctx context.Context, structType any, queryFragment string, a
 	return rows, nil
 }
 
+// Query executes a query with named parameters and returns the resulting rows.
+func (d *DB) Query(ctx context.Context, sql string, args map[string]any) (*sql.Rows, error) {
+	sql, argSlice, err := d.replaceNames(sql, args)
+	if err != nil {
+		return nil, err
+	}
+	return d.db.QueryContext(ctx, sql, argSlice...)
+}
+
+// Exec executes a query with named parameters and without returning rows.
+func (d *DB) Exec(ctx context.Context, sql string, args map[string]any) (sql.Result, error) {
+	sql, argSlice, err := d.replaceNames(sql, args)
+	if err != nil {
+		return nil, err
+	}
+	return d.db.ExecContext(ctx, sql, argSlice...)
+}
+
 func (d *DB) UpdateRecord(ctx context.Context, dest any, updates Updates) error {
 	model, err := d.newModelType(dest)
 	if err != nil {


### PR DESCRIPTION
Add `Query` and `Exec` methods to `DB`. This will allow consumers to call the underlying `sql.DB` methods , but using the `$` parameter replacement logic.
