### PR TITLE
Add experimental generics API

### DIFF
--- a/generics.go
+++ b/generics.go
@@ -1,4 +1,4 @@
-package microrm
+package dbmap
 
 import (
 	"context"

--- a/generics.go
+++ b/generics.go
@@ -1,0 +1,94 @@
+package microrm
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+)
+
+// ModelDB provides a type-safe, generic interface for database operations on a specific model type T.
+// It wraps the underlying DB instance and provides methods that automatically handle the model type.
+type ModelDB[T any] struct {
+	t  reflect.Type
+	db DB
+}
+
+// M returns a ModelDB[T] for the given type T, providing an easy-to-use API to
+// run queries against that model/table.
+func M[T any](db *DB) ModelDB[T] {
+	var _t T
+	tType := reflect.TypeOf(_t)
+
+	if tType.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("ModelDB can only be created for struct types, got %s", tType.Kind()))
+	}
+
+	return ModelDB[T]{
+		t:  reflect.TypeOf(_t),
+		db: *db,
+	}
+}
+
+// Many executes a SELECT query and returns multiple records of type T.
+// The queryFragment should contain the WHERE clause and any other SQL after SELECT.
+func (m *ModelDB[T]) Many(ctx context.Context, queryFragment string, args Args) ([]T, error) {
+	records := reflect.MakeSlice(reflect.SliceOf(m.t), 0, 0).Interface().([]T)
+	err := m.db.Select(ctx, &records, queryFragment, args)
+	if err != nil {
+		return nil, err
+	}
+
+	return records, nil
+}
+
+// Find executes a SELECT query and returns a single record of type T.
+// Returns an error if no record is found or if multiple records match.
+func (m *ModelDB[T]) Find(ctx context.Context, queryFragment string, args Args) (T, error) {
+	newRecord := reflect.New(m.t)
+	var record T
+	if m.t.Kind() == reflect.Pointer {
+		record = newRecord.Interface().(T)
+	} else {
+		record = newRecord.Elem().Interface().(T)
+	}
+
+	err := m.db.Select(ctx, &record, queryFragment, args)
+	if err != nil {
+		return record, err
+	}
+
+	return record, nil
+}
+
+// Insert inserts a new record of type T into the database.
+// The ID field will be populated with the auto-generated primary key if applicable.
+func (m *ModelDB[T]) Insert(ctx context.Context, model *T) error {
+	return m.db.Insert(ctx, model)
+}
+
+// Update executes an UPDATE query for records of type T matching the query fragment.
+// Returns the number of rows affected.
+func (m *ModelDB[T]) Update(ctx context.Context, queryFragment string, args Args, updates Updates) (int64, error) {
+	var t T
+	return m.db.Update(ctx, t, queryFragment, args, updates)
+}
+
+// Delete executes a DELETE query for records of type T matching the query fragment.
+// Returns the number of rows affected.
+func (m *ModelDB[T]) Delete(ctx context.Context, queryFragment string, args Args) (int64, error) {
+	var t T
+	return m.db.Delete(ctx, t, queryFragment, args)
+}
+
+// UpdateRecord updates a specific record by its ID field.
+// The model must have an ID field that will be used to identify the record to update.
+func (m *ModelDB[T]) UpdateRecord(ctx context.Context, model *T, updates Updates) error {
+	return m.db.UpdateRecord(ctx, model, updates)
+}
+
+// DeleteRecord deletes a specific record by its ID field.
+// The model must have an ID field that will be used to identify the record to delete.
+// Returns an error if the model doesn't have an ID field.
+func (m *ModelDB[T]) DeleteRecord(ctx context.Context, model *T) (int64, error) {
+	return m.db.DeleteRecord(ctx, model)
+}

--- a/generics.go
+++ b/generics.go
@@ -15,9 +15,9 @@ type ModelDB[T any] struct {
 // M returns a ModelDB[T] for the given type T, providing an easy-to-use API to
 // run queries against that model/table.
 func M[T any](db *DB) ModelDB[T] {
-	var t T
-	if reflect.TypeOf(t).Kind() != reflect.Struct {
-		panic(fmt.Sprintf("ModelDB can only be created for struct types, got %s", reflect.TypeOf(t)))
+	tt := reflect.TypeOf((*T)(nil)).Elem()
+	if tt.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("ModelDB can only be created for struct types, got %s", tt))
 	}
 
 	return ModelDB[T]{

--- a/generics.go
+++ b/generics.go
@@ -82,3 +82,15 @@ func (m *ModelDB[T]) UpdateRecord(ctx context.Context, model *T, updates Updates
 func (m *ModelDB[T]) DeleteRecord(ctx context.Context, model *T) (int64, error) {
 	return m.db.DeleteRecord(ctx, model)
 }
+
+// Exists returns true if any records exist using the given query fragment.
+func (m *ModelDB[T]) Exists(ctx context.Context, queryFragment string, args Args) (bool, error) {
+	var t T
+	return m.db.Exists(ctx, t, queryFragment, args)
+}
+
+// Count returns the number of records that match the provided query fragment.
+func (m *ModelDB[T]) Count(ctx context.Context, queryFragment string, args Args) (int64, error) {
+	var t T
+	return m.db.Count(ctx, t, queryFragment, args)
+}

--- a/generics_test.go
+++ b/generics_test.go
@@ -1,4 +1,4 @@
-package microrm
+package dbmap
 
 import (
 	"context"

--- a/generics_test.go
+++ b/generics_test.go
@@ -1,0 +1,219 @@
+package microrm
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelDB_Many(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := setupDB(t)
+	db := New(sqlDB)
+
+	t.Run("returns multiple key-values", func(t *testing.T) {
+		kvDB := M[KeyValue](db)
+		kvs, err := kvDB.Many(ctx, "WHERE `key` LIKE $pattern ORDER BY `key`", Args{
+			"pattern": "config.database.%",
+		})
+
+		require.NoError(t, err)
+		require.Len(t, kvs, 2)
+		require.Equal(t, "config.database.host", kvs[0].Key)
+		require.Equal(t, "localhost", kvs[0].Value)
+		require.Equal(t, "config.database.port", kvs[1].Key)
+		require.Equal(t, "3306", kvs[1].Value)
+	})
+
+	t.Run("returns empty slice when no matches", func(t *testing.T) {
+		kvDB := M[KeyValue](db)
+		kvs, err := kvDB.Many(ctx, "WHERE `key` = $key", Args{
+			"key": "nonexistent.key",
+		})
+
+		require.NoError(t, err)
+		require.Len(t, kvs, 0)
+	})
+}
+
+func TestModelDB_Find(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := setupDB(t)
+	db := New(sqlDB)
+
+	t.Run("finds single key-value", func(t *testing.T) {
+		kvDB := M[KeyValue](db)
+		kv, err := kvDB.Find(ctx, "WHERE `key` = $key", Args{
+			"key": "config.app.name",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "config.app.name", kv.Key)
+		require.Equal(t, "MicroORM", kv.Value)
+	})
+
+	t.Run("returns error when no record found", func(t *testing.T) {
+		kvDB := M[KeyValue](db)
+		_, err := kvDB.Find(ctx, "WHERE `key` = $key", Args{
+			"key": "nonexistent.key",
+		})
+
+		require.Error(t, err)
+		require.Equal(t, sql.ErrNoRows, err)
+	})
+}
+
+func TestModelDB_Insert(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := setupDB(t)
+	db := New(sqlDB)
+
+	t.Run("inserts value type", func(t *testing.T) {
+		kvDB := M[KeyValue](db)
+		kv := KeyValue{
+			Key:   "test.generics.insert.value",
+			Value: "test value insert",
+		}
+
+		err := kvDB.Insert(ctx, &kv)
+		require.NoError(t, err)
+		require.NotZero(t, kv.ID)
+
+		var retrieved KeyValue
+		err = db.Select(ctx, &retrieved, "WHERE `key` = $key", Args{
+			"key": "test.generics.insert.value",
+		})
+		require.NoError(t, err)
+		require.Equal(t, kv.ID, retrieved.ID)
+		require.Equal(t, "test value insert", retrieved.Value)
+	})
+}
+
+func TestModelDB_Update(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := setupDB(t)
+	db := New(sqlDB)
+
+	t.Run("updates with value type", func(t *testing.T) {
+		orig := &KeyValue{Key: "test.generics.update.value", Value: "before"}
+		require.NoError(t, db.Insert(ctx, orig))
+
+		kvDB := M[KeyValue](db)
+		rows, err := kvDB.Update(ctx, "WHERE `key` = $key", Args{
+			"key": "test.generics.update.value",
+		}, Updates{
+			"Value": "after",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, int64(1), rows)
+
+		var updated KeyValue
+		err = db.Select(ctx, &updated, "WHERE `key` = $key", Args{
+			"key": "test.generics.update.value",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "after", updated.Value)
+	})
+
+	t.Run("returns zero rows when no match", func(t *testing.T) {
+		kvDB := M[KeyValue](db)
+		rows, err := kvDB.Update(ctx, "WHERE `key` = $key", Args{
+			"key": "nonexistent.key",
+		}, Updates{
+			"Value": "whatever",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, int64(0), rows)
+	})
+}
+
+func TestModelDB_Delete(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := setupDB(t)
+	db := New(sqlDB)
+
+	t.Run("deletes rows", func(t *testing.T) {
+		orig := &KeyValue{Key: "test.generics.delete.value", Value: "to be deleted"}
+		require.NoError(t, db.Insert(ctx, orig))
+
+		kvDB := M[KeyValue](db)
+		rows, err := kvDB.Delete(ctx, "WHERE `key` = $key", Args{
+			"key": "test.generics.delete.value",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, int64(1), rows)
+
+		var deleted KeyValue
+		err = db.Select(ctx, &deleted, "WHERE `key` = $key", Args{
+			"key": "test.generics.delete.value",
+		})
+		require.Error(t, err)
+		require.Equal(t, sql.ErrNoRows, err)
+	})
+
+	t.Run("returns zero rows when no match", func(t *testing.T) {
+		kvDB := M[KeyValue](db)
+		rows, err := kvDB.Delete(ctx, "WHERE `key` = $key", Args{
+			"key": "nonexistent.key",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, int64(0), rows)
+	})
+}
+
+func TestModelDB_UpdateRecord(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := setupDB(t)
+	db := New(sqlDB)
+
+	t.Run("updates record", func(t *testing.T) {
+		orig := &KeyValue{Key: "test.generics.updaterecord.value", Value: "before"}
+		require.NoError(t, db.Insert(ctx, orig))
+		originalID := orig.ID
+
+		kvDB := M[KeyValue](db)
+		err := kvDB.UpdateRecord(ctx, orig, Updates{
+			"Value": "after",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, originalID, orig.ID)
+
+		var updated KeyValue
+		err = db.Select(ctx, &updated, "WHERE id = $id", Args{
+			"id": originalID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "after", updated.Value)
+	})
+}
+
+func TestModelDB_DeleteRecord(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := setupDB(t)
+	db := New(sqlDB)
+
+	t.Run("deletes record", func(t *testing.T) {
+		orig := &KeyValue{Key: "test.generics.deleterecord.value", Value: "to be deleted"}
+		require.NoError(t, db.Insert(ctx, orig))
+		originalID := orig.ID
+
+		kvDB := M[KeyValue](db)
+		n, err := kvDB.DeleteRecord(ctx, orig)
+		require.Equal(t, int64(1), n)
+		require.NoError(t, err)
+
+		var deleted KeyValue
+		err = db.Select(ctx, &deleted, "WHERE id = $id", Args{
+			"id": originalID,
+		})
+		require.Error(t, err)
+		require.Equal(t, sql.ErrNoRows, err)
+	})
+}


### PR DESCRIPTION
This adds a new `ModelDB[T]` type that wraps the existing micorm API.
It's used to provide type-safe methods, and eliminate the need for API
consumers to construct and pass a value to populate.

- `micorm.M[T]()` creates a new modelDB for type T.
- `Many` can be used to find multiple records at once.
- `Find` can be used to find a single record.
- `Update`, and `Delete` no longer need to provide a type.
- `Insert`, `UpdateRecord`, and `DeleteRecord` are now type safe(er).

This is largely a nice wrapper on-top of the existing API, fow now:

```go
userDB := dbmap.M[User](db)

users, err := userDB.Many(ctx, "WHERE active = $active", dbmap.Args{"active": true})
user, err := userDB.Find(ctx, "WHERE email = $email", dbmap.Args{"email": "test@example.com"})
err = userDB.Insert(ctx, &newUser)
```
